### PR TITLE
Work around missing cURL constants in some verisons of HHVM

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
   },
   "require": {
     "ext-curl": "*",
-    "lib-curl": ">=7.15.1",
     "php": ">=5.5.9"
   },
   "require-dev": {

--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -241,7 +241,11 @@ class CheckIfDead {
 			$options[CURLOPT_FTP_USE_EPRT] = 1;
 			$options[CURLOPT_FTP_USE_EPSV] = 1;
 			$options[CURLOPT_FTPSSLAUTH] = CURLFTPAUTH_DEFAULT;
-			$options[CURLOPT_FTP_FILEMETHOD] = CURLFTPMETHOD_SINGLECWD;
+			if ( defined( 'CURLOPT_FTP_FILEMETHOD' ) ) {
+				// Requires libcurl >= 7.15.1
+				// Mot available with HHVM <3.14.0
+				$options[CURLOPT_FTP_FILEMETHOD] = CURLFTPMETHOD_SINGLECWD;
+			}
 		}
 		if ( $full ) {
 			$options[CURLOPT_USERPWD] = "anonymous:anonymous@domain.com";


### PR DESCRIPTION
HHVM versions before https://github.com/facebook/hhvm/commit/575aaf9
(<3.14.4) are missing some cURL constants even when the linked cURL
library supports them.