### PR TITLE
Update CID to v1.1.5.1

### DIFF
--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -6,7 +6,7 @@
  */
 namespace Wikimedia\DeadlinkChecker;
 
-define( 'CHECKIFDEADVERSION', '1.1.5' );
+define( 'CHECKIFDEADVERSION', '1.1.5.1' );
 
 class CheckIfDead {
 
@@ -454,7 +454,7 @@ class CheckIfDead {
 				array_map( "rawurlencode",
 					explode( '/',
 						substr(
-							urldecode( $parts['path'] ), 1
+							rawurldecode( $parts['path'] ), 1
 						)
 					)
 				)

--- a/tests/checkIfDeadTest.php
+++ b/tests/checkIfDeadTest.php
@@ -120,6 +120,9 @@ class CheckIfDeadTest extends PHPUnit_Framework_TestCase {
 			],
 			[ 'https:/zh.wikipedia.org/wiki/猫', 'https://zh.wikipedia.org/wiki/%E7%8C%AB' ],
 			[ 'zh.wikipedia.org/wiki/猫', 'http://zh.wikipedia.org/wiki/%E7%8C%AB' ],
+			[ 'http://www.cabelas.com/story-123/boddington_short_mag/10201/The+Short+Mag+Revolution.shtml',
+				'http://www.cabelas.com/story-123/boddington_short_mag/10201/The%2BShort%2BMag%2BRevolution.shtml'
+			],
 		];
 		// @codingStandardsIgnoreEnd
 		if ( function_exists( 'idn_to_ascii' ) ) {


### PR DESCRIPTION
Fixed an encoding/decoding mismatch, that was breaking certain URLs,
and consequently also caused the CID to report a false positive.

Added a test case.