### PR TITLE
Add some idiot proofing.

### DIFF
--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -499,7 +499,7 @@ class CheckIfDead {
 	public function parseURL( $url ) {
 		// Feeding fully encoded URLs will not work.  So let's detect and decode if needed first.
 		// This is just idiot proofing.
-		if ( preg_match( '/^([a-z0-9\+\-\.]*\%3a)?\%2f/i', $url ) ) {
+		if ( preg_match( '/^([a-z0-9\+\-\.]*\%3a)?(?:\%2f|\/)/i', $url ) ) {
 			$url = urldecode( $url );
 		}
 		// Sometimes the scheme is followed by a single slash instead of a double.

--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -6,7 +6,7 @@
  */
 namespace Wikimedia\DeadlinkChecker;
 
-define( 'CHECKIFDEADVERSION', '1.1.5.1' );
+define( 'CHECKIFDEADVERSION', '1.1.6' );
 
 class CheckIfDead {
 
@@ -497,6 +497,11 @@ class CheckIfDead {
 	 *     array( 'scheme' => 'https', 'host' => 'hello.com', 'path' => '/en/' ) )
 	 */
 	public function parseURL( $url ) {
+		// Feeding fully encoded URLs will not work.  So let's detect and decode if needed first.
+		// This is just idiot proofing.
+		if ( preg_match( '/^([a-z0-9\+\-\.]*\%3a)?\%2f/i', $url ) ) {
+			$url = urldecode( $url );
+		}
 		// Sometimes the scheme is followed by a single slash instead of a double.
 		// Web browsers and archives support this, so we should too.
 		if ( preg_match( '/^([a-z0-9\+\-\.]*:)?\/([^\/].+)/i', $url, $match ) ) {

--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -499,9 +499,7 @@ class CheckIfDead {
 	public function parseURL( $url ) {
 		// Feeding fully encoded URLs will not work.  So let's detect and decode if needed first.
 		// This is just idiot proofing.
-		if ( preg_match( '/^([a-z0-9\+\-\.]*\%3a)?(?:\%2f|\/)/i', $url ) ) {
-			$url = urldecode( $url );
-		}
+		$url = rawurldecode( $url );
 		// Sometimes the scheme is followed by a single slash instead of a double.
 		// Web browsers and archives support this, so we should too.
 		if ( preg_match( '/^([a-z0-9\+\-\.]*:)?\/([^\/].+)/i', $url, $match ) ) {

--- a/tests/checkIfDeadTest.php
+++ b/tests/checkIfDeadTest.php
@@ -125,6 +125,8 @@ class CheckIfDeadTest extends PHPUnit_Framework_TestCase {
 			],
 			[ 'http%3A%2F%2Fwww.sports-reference.com%2Folympics%2Fwinter%2F1994%2FNCO%2Fmens-team.html',
 				'http://www.sports-reference.com/olympics/winter/1994/NCO/mens-team.html' ],
+			[ 'http%3A//www%2Eatimes%2Ecom/atimes/Middle_East/FH13Ak05%2Ehtml',
+				'http://www.atimes.com/atimes/Middle_East/FH13Ak05.html' ],
 		];
 		// @codingStandardsIgnoreEnd
 		if ( function_exists( 'idn_to_ascii' ) ) {

--- a/tests/checkIfDeadTest.php
+++ b/tests/checkIfDeadTest.php
@@ -123,6 +123,8 @@ class CheckIfDeadTest extends PHPUnit_Framework_TestCase {
 			[ 'http://www.cabelas.com/story-123/boddington_short_mag/10201/The+Short+Mag+Revolution.shtml',
 				'http://www.cabelas.com/story-123/boddington_short_mag/10201/The%2BShort%2BMag%2BRevolution.shtml'
 			],
+			[ 'http%3A%2F%2Fwww.sports-reference.com%2Folympics%2Fwinter%2F1994%2FNCO%2Fmens-team.html',
+				'http://www.sports-reference.com/olympics/winter/1994/NCO/mens-team.html' ],
 		];
 		// @codingStandardsIgnoreEnd
 		if ( function_exists( 'idn_to_ascii' ) ) {


### PR DESCRIPTION
Add a check to properly handle fully encoded URLs.

IABot sometimes sends fully encoded URLs to the sanitizer which comes back broken.  

These calls are everywhere, and would be easier and more logical to put the check here.