### PR TITLE
Update CID to v1.3

### DIFF
--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -393,7 +393,7 @@ class CheckIfDead {
 	 *
 	 * @param string $url URL to sanitize
 	 * @param bool $stripFragment Remove the fragment from the URL.
-	 * @param bool $preserveQueryEncoding Preserve the whitespace encoding of query strings.  Otherwise convert to %20.
+	 * @param bool $preserveQueryEncoding Preserve the whitespace encoding of query strings.
 	 * @return string sanitized URL
 	 */
 	public function sanitizeURL( $url, $stripFragment = false, $preserveQueryEncoding = false ) {
@@ -407,7 +407,7 @@ class CheckIfDead {
 		// Some rare URLs don't like it when %20 is passed in the query and require the +.
 		// %20 is the most common usage to represent a whitespace in the query.
 		// So convert them to unique values that will survive the encoding/decoding process.
-		if( $preserveQueryEncoding === true && isset( $parts['query'] ) ) {
+		if ( $preserveQueryEncoding === true && isset( $parts['query'] ) ) {
 			$parts['query'] = str_replace( "%20", "CHECKIFDEADHEXSPACE", $parts['query'] );
 			$parts['query'] = str_replace( "+", "CHECKIFDEADPLUSSPACE", $parts['query'] );
 		}
@@ -504,7 +504,7 @@ class CheckIfDead {
 		}
 
 		// Convert our identifiers back into URL elements.
-		if( $preserveQueryEncoding === true ) {
+		if ( $preserveQueryEncoding === true ) {
 			$url = str_replace( "CHECKIFDEADHEXSPACE", "%20", $url );
 			$url = str_replace( "CHECKIFDEADPLUSSPACE", "+", $url );
 		}

--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -407,7 +407,7 @@ class CheckIfDead {
 		// Some rare URLs don't like it when %20 is passed in the query and require the +.
 		// %20 is the most common usage to represent a whitespace in the query.
 		// So convert them to unique values that will survive the encoding/decoding process.
-		if( $preserveQueryEncoding === true ) {
+		if( $preserveQueryEncoding === true && isset( $parts['query'] ) ) {
 			$parts['query'] = str_replace( "%20", "CHECKIFDEADHEXSPACE", $parts['query'] );
 			$parts['query'] = str_replace( "+", "CHECKIFDEADPLUSSPACE", $parts['query'] );
 		}

--- a/tests/checkIfDeadTest.php
+++ b/tests/checkIfDeadTest.php
@@ -37,6 +37,10 @@ class CheckIfDeadTest extends PHPUnit_Framework_TestCase {
 			[ 'http://archives.lse.ac.uk/TreeBrowse.aspx?src=CalmView.Catalog&field=RefNo&key=RICHARDS', false ],
 			[ 'https://en.wikipedia.org/w/index.php?title=Wikipedia:Templates_for_discussion/Holding%20cell&action=edit', false ],
 			[ 'http://hei.hankyung.com/news/app/newsview.php?aid=2011080869717', false ],
+			[
+				'http://www.usnews.com/news/blogs/god-and-country/2009/06/30/time-report-white-house-reaction-raise-more-questions-about-obamas-church-hunt',
+				false
+			],
 
 			[ 'https://en.wikipedia.org/nothing', true ],
 			[ '//en.wikipedia.org/nothing', true ],

--- a/tests/checkIfDeadTest.php
+++ b/tests/checkIfDeadTest.php
@@ -37,10 +37,6 @@ class CheckIfDeadTest extends PHPUnit_Framework_TestCase {
 			[ 'http://archives.lse.ac.uk/TreeBrowse.aspx?src=CalmView.Catalog&field=RefNo&key=RICHARDS', false ],
 			[ 'https://en.wikipedia.org/w/index.php?title=Wikipedia:Templates_for_discussion/Holding%20cell&action=edit', false ],
 			[ 'http://hei.hankyung.com/news/app/newsview.php?aid=2011080869717', false ],
-			[
-				'http://www.usnews.com/news/blogs/god-and-country/2009/06/30/time-report-white-house-reaction-raise-more-questions-about-obamas-church-hunt',
-				false
-			],
 
 			[ 'https://en.wikipedia.org/nothing', true ],
 			[ '//en.wikipedia.org/nothing', true ],


### PR DESCRIPTION
Some sites were coming back as false positives as a result of the UA, so
it's been replaced with a UA from the most up to date Chrome browser.
Some sites, despite the fact they should be able to handle them, only
exclusively support the + or the %20 in the query string to represent a
whitespace.  The most common usage is %20 which is what the sanitizer
sanitizes to, but some sites exlcusively use the + instead in which case
it would break the URL and deliver a bad result.  So the option to
preserve the existing encoding format has been added to the sanitizer
and full requests now preserve the encoding.
Also fixed an encoding parameter.  Could be a possible issue, that we
should avoid.