### PR TITLE
Update CID to v1.3.1

### DIFF
--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -467,6 +467,8 @@ class CheckIfDead {
 		// This avoids possible 400 Bad Response errors.
 		$url .= "/";
 		if ( isset( $parts['path'] ) && strlen( $parts['path'] ) > 1 ) {
+			// Pluses in the path are legal characters that do not need to be encoded.
+			// Some URLs don't like the plus encoded.
 			$parts['path'] = str_replace( "+", "CHECKIFDEADPLUSSPACE", $parts['path'] );
 			$url .= implode( '/',
 				array_map( "rawurlencode",
@@ -525,7 +527,7 @@ class CheckIfDead {
 	public function parseURL( $url ) {
 		// Feeding fully encoded URLs will not work.  So let's detect and decode if needed first.
 		// This is just idiot proofing.
-		// Make sure URL is fully encoded by checking if the :// is encoded.
+		// See if the URL is fully encoded by checking if the :// is encoded.
 		// This prevents URLs where double encoded values aren't mistakenly decoded breaking the URL.
 		if ( preg_match( '/^([a-z0-9\+\-\.]*)(?:%3A%2F%2F|%3A\/\/|:%2F%2F)/i', $url ) ) {
 			// First let's break the fragment out to prevent accidentally mistaking a decoded %23 as a #

--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -4,6 +4,7 @@
  *
  * @license https://www.gnu.org/licenses/gpl.txt
  */
+
 namespace Wikimedia\DeadlinkChecker;
 
 define( 'CHECKIFDEADVERSION', '1.3.1' );
@@ -17,6 +18,7 @@ class CheckIfDead {
 	protected $userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36";
 
 	// @codingStandardsIgnoreEnd
+
 	/**
 	 *  HTTP codes that do not indicate a dead link
 	 */
@@ -403,14 +405,12 @@ class CheckIfDead {
 		// can't handle decoded characters.
 		// Break up the URL first
 		$parts = $this->parseURL( $url );
-
 		// Some rare URLs don't like it when %20 is passed in the query and require the +.
 		// %20 is the most common usage to represent a whitespace in the query.
 		// So convert them to unique values that will survive the encoding/decoding process.
 		if ( $preserveQueryEncoding === true && isset( $parts['query'] ) ) {
 			$parts['query'] = str_replace( "%20", "CHECKIFDEADHEXSPACE", $parts['query'] );
 		}
-
 		// In case the protocol is missing, assume it goes to HTTPS
 		if ( !isset( $parts['scheme'] ) ) {
 			$url = "https";
@@ -506,9 +506,7 @@ class CheckIfDead {
 			// We don't need to encode the fragment, that's handled client side anyways.
 			$url .= "#" . $parts['fragment'];
 		}
-
 		$url = str_replace( "CHECKIFDEADPLUSSPACE", "+", $url );
-
 		// Convert our identifiers back into URL elements.
 		if ( $preserveQueryEncoding === true ) {
 			$url = str_replace( "CHECKIFDEADHEXSPACE", "%20", $url );
@@ -529,7 +527,7 @@ class CheckIfDead {
 		// This is just idiot proofing.
 		// Make sure URL is fully encoded by checking if the :// is encoded.
 		// This prevents URLs where double encoded values aren't mistakenly decoded breaking the URL.
-		if( preg_match( '/^([a-z0-9\+\-\.]*)(?:%3A%2F%2F|%3A\/\/|:%2F%2F)/i', $url ) ) {
+		if ( preg_match( '/^([a-z0-9\+\-\.]*)(?:%3A%2F%2F|%3A\/\/|:%2F%2F)/i', $url ) ) {
 			// First let's break the fragment out to prevent accidentally mistaking a decoded %23 as a #
 			$fragment = parse_url( $url, PHP_URL_FRAGMENT );
 			if ( !is_null( $fragment ) ) {

--- a/tests/checkIfDeadTest.php
+++ b/tests/checkIfDeadTest.php
@@ -37,6 +37,7 @@ class CheckIfDeadTest extends PHPUnit_Framework_TestCase {
 			[ 'http://archives.lse.ac.uk/TreeBrowse.aspx?src=CalmView.Catalog&field=RefNo&key=RICHARDS', false ],
 			[ 'https://en.wikipedia.org/w/index.php?title=Wikipedia:Templates_for_discussion/Holding%20cell&action=edit', false ],
 			[ 'http://hei.hankyung.com/news/app/newsview.php?aid=2011080869717', false ],
+			[ 'http://www.musicvf.com/Buck+Owens+%2526+Ringo+Starr.art', false ],
 
 			[ 'https://en.wikipedia.org/nothing', true ],
 			[ '//en.wikipedia.org/nothing', true ],
@@ -122,7 +123,7 @@ class CheckIfDeadTest extends PHPUnit_Framework_TestCase {
 			[ 'https:/zh.wikipedia.org/wiki/猫', 'https://zh.wikipedia.org/wiki/%E7%8C%AB' ],
 			[ 'zh.wikipedia.org/wiki/猫', 'http://zh.wikipedia.org/wiki/%E7%8C%AB' ],
 			[ 'http://www.cabelas.com/story-123/boddington_short_mag/10201/The+Short+Mag+Revolution.shtml',
-				'http://www.cabelas.com/story-123/boddington_short_mag/10201/The%2BShort%2BMag%2BRevolution.shtml'
+				'http://www.cabelas.com/story-123/boddington_short_mag/10201/The+Short+Mag+Revolution.shtml'
 			],
 			[ 'http%3A%2F%2Fwww.sports-reference.com%2Folympics%2Fwinter%2F1994%2FNCO%2Fmens-team.html',
 				'http://www.sports-reference.com/olympics/winter/1994/NCO/mens-team.html' ],
@@ -132,12 +133,10 @@ class CheckIfDeadTest extends PHPUnit_Framework_TestCase {
 				'http://www.eurostar.se/html/bokning.php?ort=Falk%F6ping'],
 			[ 'http://www.silvercityvault.org.uk/index.php?a=ViewItem&key=SHsiRCI6IlN1YmplY3QgPSBcIkJyaWRnZXNcIiIsIk4iOjUyLCJQIjp7InN1YmplY3RfaWQiOiIyMCIsImpvaW5fb3AiOjJ9fQ%3D%3D&pg=8&WINID=1384795972907#YqFdqg6Pj8MAAAFCbEWeJA/67',
 				'http://www.silvercityvault.org.uk/index.php?a=ViewItem&key=SHsiRCI6IlN1YmplY3QgPSBcIkJyaWRnZXNcIiIsIk4iOjUyLCJQIjp7InN1YmplY3RfaWQiOiIyMCIsImpvaW5fb3AiOjJ9fQ%3D%3D&pg=8&WINID=1384795972907' ],
-			[ 'http://www.gcis.gov.za/gcis/gcis_list.jsp?id=14&heading=Executive+Mayors',
-				'http://www.gcis.gov.za/gcis/gcis_list.jsp?id=14&heading=Executive%20Mayors' ],
-			[ 'http://example.com/blue+light%20blue?blue%2Blight+blue',
-				'http://example.com/blue%2Blight%20blue?blue%20light%20blue' ],
 			[ 'http://example.com/blue+light%20blue?blue%2Blight+blue%23foobar#foobar',
-				'http://example.com/blue%2Blight%20blue?blue%20light%20blue%23foobar' ],
+				'http://example.com/blue+light%20blue?blue%2Blight+blue%23foobar' ],
+			[ 'http://www.musicvf.com/Buck+Owens+%2526+Ringo+Starr.art',
+				'http://www.musicvf.com/Buck+Owens+%2526+Ringo+Starr.art' ]
 		];
 		// @codingStandardsIgnoreEnd
 		if ( function_exists( 'idn_to_ascii' ) ) {


### PR DESCRIPTION
This update makes the following changes:
*Pluses in the paths are not forcibly encoded to %2B.  They are legal
characters in URLs
*Pluses in the queries are not forcibly encoded to %2B as %2B means a
literal plus, and the plus means a space.
*The idiot proof check now uses a sanity check to ensure the URL is
fully encoded to prevent accidental decoding of double URLs.

Tests:
*Added URL http://www.musicvf.com/Buck+Owens+%2526+Ringo+Starr.art
which came back dead with the algorithm.
*Added same URL to the sanitizing test to test new sanity check
*Removed a couple of now useless tests, where URLs returned are
identical to the input.