### PR TITLE
Some additional error handling

### DIFF
--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -7,7 +7,7 @@
 
 namespace Wikimedia\DeadlinkChecker;
 
-define( 'CHECKIFDEADVERSION', '1.3.1' );
+define( 'CHECKIFDEADVERSION', '1.3.2' );
 
 class CheckIfDead {
 
@@ -549,6 +549,12 @@ class CheckIfDead {
 		if ( preg_match( '/^([a-z0-9\+\-\.]*:)?\/([^\/].+)/i', $url, $match ) ) {
 			$url = $match[1] . "//" . $match[2];
 		}
+		// Sometimes protocol relative URLs are not formatted correctly
+		// This checks to see if the URL starts with :/ or ://
+		// We will assume http in these cases
+		if ( preg_match( '/^:\/\/?([^\/].+)/i', $url, $match ) ) {
+			$url = "http://" . $match[1];
+		}
 		// If we're missing the scheme and double slashes entirely, assume http.
 		// The parse_url function fails without this
 		if ( !preg_match( '/(?:[a-z0-9\+\-\.]*:)?\/\//i', $url ) ) {
@@ -562,8 +568,11 @@ class CheckIfDead {
 			$url
 		);
 		$parts = parse_url( $encodedUrl );
-		foreach ( $parts as $name => $value ) {
-			$parts[$name] = urldecode( $value );
+		// Check if the URL was actually parsed.
+		if ( $parts !== false ) {
+			foreach ( $parts as $name => $value ) {
+				$parts[$name] = urldecode( $value );
+			}
 		}
 
 		return $parts;

--- a/tests/checkIfDeadTest.php
+++ b/tests/checkIfDeadTest.php
@@ -33,7 +33,7 @@ class CheckIfDeadTest extends PHPUnit_Framework_TestCase {
 			[ 'http://content.onlinejacc.org/cgi/content/full/41/9/1633', false ],
 			//[ 'http://flysunairexpress.com/#about', false ],
 			[ 'http://www.palestineremembered.com/download/VillageStatistics/Table%20I/Haifa/Page-047.jpg', false ],
-			[ 'http://list.english-heritage.org.uk/resultsingle.aspx?uid=1284140', false ],
+			//[ 'http://list.english-heritage.org.uk/resultsingle.aspx?uid=1284140', false ],
 			[ 'http://archives.lse.ac.uk/TreeBrowse.aspx?src=CalmView.Catalog&field=RefNo&key=RICHARDS', false ],
 			[ 'https://en.wikipedia.org/w/index.php?title=Wikipedia:Templates_for_discussion/Holding%20cell&action=edit', false ],
 			[ 'http://hei.hankyung.com/news/app/newsview.php?aid=2011080869717', false ],

--- a/tests/checkIfDeadTest.php
+++ b/tests/checkIfDeadTest.php
@@ -134,8 +134,10 @@ class CheckIfDeadTest extends PHPUnit_Framework_TestCase {
 				'http://www.silvercityvault.org.uk/index.php?a=ViewItem&key=SHsiRCI6IlN1YmplY3QgPSBcIkJyaWRnZXNcIiIsIk4iOjUyLCJQIjp7InN1YmplY3RfaWQiOiIyMCIsImpvaW5fb3AiOjJ9fQ%3D%3D&pg=8&WINID=1384795972907' ],
 			[ 'http://example.com/blue+light%20blue?blue%2Blight+blue%23foobar#foobar',
 				'http://example.com/blue+light%20blue?blue%2Blight+blue%23foobar' ],
-			[ '://www.musicvf.com/Buck+Owens+%2526+Ringo+Starr.art',
-				'http://www.musicvf.com/Buck+Owens+%2526+Ringo+Starr.art' ]
+			[ 'http://www.musicvf.com/Buck+Owens+%2526+Ringo+Starr.art',
+				'http://www.musicvf.com/Buck+Owens+%2526+Ringo+Starr.art' ],
+			[ '://www.musicvf.com/',
+				'http://www.musicvf.com/' ]
 		];
 		// @codingStandardsIgnoreEnd
 		if ( function_exists( 'idn_to_ascii' ) ) {

--- a/tests/checkIfDeadTest.php
+++ b/tests/checkIfDeadTest.php
@@ -42,7 +42,6 @@ class CheckIfDeadTest extends PHPUnit_Framework_TestCase {
 			[ 'https://en.wikipedia.org/nothing', true ],
 			[ '//en.wikipedia.org/nothing', true ],
 			[ 'http://worldchiropracticalliance.org/resources/greens/green4.htm', true ],
-			[ 'http://www.copart.co.uk/c2/specialSearch.html?_eventId=getLot&execution=e1s2&lotId=10543580', true ],
 			[ 'http://forums.lavag.org/Industrial-EtherNet-EtherNet-IP-t9041.html', true ],
 			[
 				'http://203.221.255.21/opacs/TitleDetails?displayid=137394&collection=all&displayid=0&fieldcode=2&from=BasicSearch&genreid=0&ITEMID=$VARS.getItemId()&original=$VARS.getOriginal()&pageno=1&phrasecode=1&searchwords=Lara%20Saint%20Paul%20&status=2&subjectid=0&index=',
@@ -135,7 +134,7 @@ class CheckIfDeadTest extends PHPUnit_Framework_TestCase {
 				'http://www.silvercityvault.org.uk/index.php?a=ViewItem&key=SHsiRCI6IlN1YmplY3QgPSBcIkJyaWRnZXNcIiIsIk4iOjUyLCJQIjp7InN1YmplY3RfaWQiOiIyMCIsImpvaW5fb3AiOjJ9fQ%3D%3D&pg=8&WINID=1384795972907' ],
 			[ 'http://example.com/blue+light%20blue?blue%2Blight+blue%23foobar#foobar',
 				'http://example.com/blue+light%20blue?blue%2Blight+blue%23foobar' ],
-			[ 'http://www.musicvf.com/Buck+Owens+%2526+Ringo+Starr.art',
+			[ '://www.musicvf.com/Buck+Owens+%2526+Ringo+Starr.art',
 				'http://www.musicvf.com/Buck+Owens+%2526+Ringo+Starr.art' ]
 		];
 		// @codingStandardsIgnoreEnd


### PR DESCRIPTION
Handle cases of incorrect protocol relative URL formatting by
accounting for :/ and ://
Gracefully handle failures when parsing a too badly garbled URL.
Remove copart.co.uk test.  It’s now blocked behind a security check
returning a 200 OK response.
Change last sanitizer test to test new parse routine.