### PR TITLE
Update CID to v1.3.3

### DIFF
--- a/tests/checkIfDeadTest.php
+++ b/tests/checkIfDeadTest.php
@@ -31,13 +31,17 @@ class CheckIfDeadTest extends PHPUnit_Framework_TestCase {
 				false
 			],
 			[ 'http://content.onlinejacc.org/cgi/content/full/41/9/1633', false ],
-			//[ 'http://flysunairexpress.com/#about', false ],
+			[ 'http://flysunairexpress.com/#about', false ],
 			[ 'http://www.palestineremembered.com/download/VillageStatistics/Table%20I/Haifa/Page-047.jpg', false ],
-			//[ 'http://list.english-heritage.org.uk/resultsingle.aspx?uid=1284140', false ],
+			[ 'http://list.english-heritage.org.uk/resultsingle.aspx?uid=1284140', false ],
 			[ 'http://archives.lse.ac.uk/TreeBrowse.aspx?src=CalmView.Catalog&field=RefNo&key=RICHARDS', false ],
 			[ 'https://en.wikipedia.org/w/index.php?title=Wikipedia:Templates_for_discussion/Holding%20cell&action=edit', false ],
 			[ 'http://hei.hankyung.com/news/app/newsview.php?aid=2011080869717', false ],
 			[ 'http://www.musicvf.com/Buck+Owens+%2526+Ringo+Starr.art', false ],
+			[
+				'http://www.filmportal.de/df/3b/Uebersicht,,,,,,,,6C95360CB3D34FDCB6A025F2618E7495,,,,,,,,,,,,,,,,,,,,,,,,,,,.html',
+				false
+			],
 
 			[ 'https://en.wikipedia.org/nothing', true ],
 			[ '//en.wikipedia.org/nothing', true ],


### PR DESCRIPTION
Skip sanitizing path and query if it contains only legal characters.
Some Webservers don’t like it if legal characters are encoded.
Uncomment the 2 tests in hopes Travis will work on them again.
Add filmportal.de test which was failing with prior versions.