### PR TITLE
Update CID to v1.4

### DIFF
--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -248,7 +248,7 @@ class CheckIfDead {
 			$options[CURLOPT_FTP_USE_EPSV] = 1;
 			$options[CURLOPT_FTPSSLAUTH] = CURLFTPAUTH_DEFAULT;
 			$options[CURLOPT_FTP_FILEMETHOD] = CURLFTPMETHOD_SINGLECWD;
-			if( $full ) {
+			if ( $full ) {
 				// Set CURLOPT_USERPWD for anonymous FTP login
 				$options[CURLOPT_USERPWD] = "anonymous:anonymous@domain.com";
 			}

--- a/tests/checkIfDeadTest.php
+++ b/tests/checkIfDeadTest.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once __DIR__ . '/../vendor/autoload.php';
+
 use Wikimedia\DeadlinkChecker\CheckIfDead;
 
 class CheckIfDeadTest extends PHPUnit_Framework_TestCase {
@@ -42,6 +43,15 @@ class CheckIfDeadTest extends PHPUnit_Framework_TestCase {
 				'http://www.filmportal.de/df/3b/Uebersicht,,,,,,,,6C95360CB3D34FDCB6A025F2618E7495,,,,,,,,,,,,,,,,,,,,,,,,,,,.html',
 				false
 			],
+			[ 'http://www.beweb.chiesacattolica.it/diocesi/diocesi/503/Aosta', false ],
+			[ 'http://www.dioceseoflascruces.org/', false ],
+			[ 'http://www.worcesterdiocese.org/', false ],
+			[ 'http://www.catholicdos.org/', false ],
+			[ 'http://www.diocesitivoli.it/', false ],
+			[ 'http://www.victoriadiocese.org/', false ],
+			[ 'http://www.saginaw.org/', false ],
+			[ 'http://www.dioceseofprovidence.org/', false ],
+			[ 'http://www.rcdop.org.uk/', false ],
 
 			[ 'https://en.wikipedia.org/nothing', true ],
 			[ '//en.wikipedia.org/nothing', true ],


### PR DESCRIPTION
*FTP logins were being applied to full request regardless if the
request type was FTP or not.  This is was causing a lot of false
positives to be reported in regards to servers returning 401 errors.
*Expanded NO RESPONSE FROM SERVER errors to full requests as some
servers simply ignore HEAD requests.

*Added test cases for sites that were returning 401 errors or empty
responses for the old version of CID.