### PR TITLE
Allow the timeouts to be configurable per instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ $ git clone https://github.com/wikimedia/DeadlinkChecker.git
 ##### For checking a single link:
 
 ```
-$obj = new checkIfDead();
+$deadLinkChecker = new checkIfDead();
 $url = 'https://en.wikipedia.org';
-$exec = $obj->isLinkDead( $url );
+$exec = $deadLinkChecker->isLinkDead( $url );
 echo var_export( $exec );
 ```
 Prints:
@@ -40,9 +40,9 @@ false
 ```
 ##### For checking an array of links:
 ```
-$obj = new checkIfDead();
+$deadLinkChecker = new checkIfDead();
 $urls = [ 'https://en.wikipedia.org/nothing', 'https://en.wikipedia.org' ];
-$exec = $obj->areLinksDead( $urls );
+$exec = $deadLinkChecker->areLinksDead( $urls );
 echo var_export( $exec );
 ```
 Prints:
@@ -59,7 +59,7 @@ Note that these functions will return `null` if they are unable to determine whe
 
 You can control how long it takes before page requests timeout by passing parameters to the constructor. To set the header-only page requests to a 10 second timeout and the full page requests to a 20 second timeout, you would use the following:
 ```
-$obj = new checkIfDead( 10, 20 );
+$deadLinkChecker = new checkIfDead( 10, 20 );
 ```
 
 ### License

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ This is a PHP library for detecting whether URLs on the internet are alive or de
 * Supports HTTP, HTTPS, FTP, MMS, and RTSP URLs
 * Supports [internationalized domain names](https://en.wikipedia.org/wiki/Internationalized_domain_name)
 * Correctly reports [soft 404s](https://en.wikipedia.org/wiki/HTTP_404#Soft_404_errors) as dead (in most cases)
+For optimized performance, it initially performs a header-only page request (CURLOPT_NOBODY). If that request fails, it then tries to do a normal full body page request.
 
 [![Build Status](https://travis-ci.org/wikimedia/DeadlinkChecker.svg?branch=master)](https://travis-ci.org/wikimedia/DeadlinkChecker)
 ### Installation
@@ -23,8 +24,7 @@ $ git clone https://github.com/wikimedia/DeadlinkChecker.git
 ```
 
 
-### Usage
-Sample usage:
+### Basic Usage
 
 ##### For checking a single link:
 
@@ -54,6 +54,13 @@ array (
 ```
 
 Note that these functions will return `null` if they are unable to determine whether a link is alive or dead.
+
+### Advanced Usage
+
+You can control how long it takes before page requests timeout by passing parameters to the constructor. To set the header-only page requests to a 10 second timeout and the full page requests to a 20 second timeout, you would use the following:
+```
+$obj = new checkIfDead( 10, 20 );
+```
 
 ### License
 This code is distributed under [GNU GPLv3+](https://www.gnu.org/copyleft/gpl.html)

--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -72,7 +72,7 @@ class CheckIfDead {
 	 *
 	 * @param int $curlTimeoutNoBody Curl timeout for header-only page requests, in seconds
 	 * @param int $curlTimeoutFull Curl timeout for full page requests, in seconds
-	 */	
+	 */
 	public function __construct( $curlTimeoutNoBody = 30, $curlTimeoutFull = 60 ) {
 		$this->curlTimeoutNoBody = (int)$curlTimeoutNoBody;
 		$this->curlTimeoutFull = (int)$curlTimeoutFull;

--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -7,9 +7,19 @@
 
 namespace Wikimedia\DeadlinkChecker;
 
-define( 'CHECKIFDEADVERSION', '1.5.1' );
+define( 'CHECKIFDEADVERSION', '1.6.0' );
 
 class CheckIfDead {
+
+	/**
+	 * Curl timeout for header-only page requests (CURLOPT_NOBODY), in seconds
+	 */
+	protected $curlTimeoutNoBody;
+
+	/**
+	 * Curl timeout for full page requests, in seconds
+	 */
+	protected $curlTimeoutFull;
 
 	/**
 	 * UserAgent for the device/browser we are pretending to be
@@ -56,6 +66,17 @@ class CheckIfDead {
 	 * dead, indexed by URL
 	 */
 	protected $errors = [];
+
+	/**
+	 * Set up the class instance
+	 *
+	 * @param int $curlTimeoutNoBody Curl timeout for header-only page requests, in seconds
+	 * @param int $curlTimeoutFull Curl timeout for full page requests, in seconds
+	 */	
+	public function __construct( $curlTimeoutNoBody = 30, $curlTimeoutFull = 60 ) {
+		$this->curlTimeoutNoBody = (int)$curlTimeoutNoBody;
+		$this->curlTimeoutFull = (int)$curlTimeoutFull;
+	}
 
 	/**
 	 * Check if a single URL is dead by performing a curl request
@@ -239,7 +260,7 @@ class CheckIfDead {
 			CURLOPT_RETURNTRANSFER => true,
 			CURLOPT_AUTOREFERER => true,
 			CURLOPT_FOLLOWLOCATION => true,
-			CURLOPT_TIMEOUT => 30,
+			CURLOPT_TIMEOUT => $this->curlTimeoutNoBody,
 			CURLOPT_SSL_VERIFYPEER => false,
 			CURLOPT_COOKIEJAR => sys_get_temp_dir() . "checkifdead.cookies.dat"
 		];
@@ -274,7 +295,7 @@ class CheckIfDead {
 		}
 		if ( $full ) {
 			// Extend timeout since we are requesting the full body
-			$options[CURLOPT_TIMEOUT] = 60;
+			$options[CURLOPT_TIMEOUT] = $this->curlTimeoutFull;
 			$options[CURLOPT_HTTPHEADER] = $header;
 			if ( $requestType != "MMS" && $requestType != "RTSP" ) {
 				$options[CURLOPT_ENCODING] = 'gzip,deflate';


### PR DESCRIPTION
In some cases, people only want to do quick cursory checks, and don't want to wait a long time for the results. In other cases, they want to be absolutely sure of the results and may want to use longer timeouts.