### PR TITLE
Support 'customUserAgent' in both HEAD (nobody) and GET (full) methods

### DIFF
--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -406,7 +406,6 @@ class CheckIfDead {
 			if ( $requestType != "MMS" && $requestType != "RTSP" ) {
 				$options[CURLOPT_ENCODING] = 'gzip,deflate';
 			}
-			$options[CURLOPT_USERAGENT] = $this->userAgent;
 		} else {
 			$options[CURLOPT_NOBODY] = 1;
 		}


### PR DESCRIPTION
The CURLOPT_USERAGENT option was already set in the previous code,
but was set a second time (without the customUserAgent check) in
the 'full' conditional block.