### PR TITLE
Make ' illegal

### DIFF
--- a/src/CheckIfDead.php
+++ b/src/CheckIfDead.php
@@ -7,7 +7,7 @@
 
 namespace Wikimedia\DeadlinkChecker;
 
-define( 'CHECKIFDEADVERSION', '1.8.3.1' );
+define( 'CHECKIFDEADVERSION', '1.8.3.2' );
 
 class CheckIfDead {
 
@@ -814,7 +814,7 @@ class CheckIfDead {
 			// There are legal characters that do not need encoding in the path
 			// and some webservers cannot handle these being encoded
 			// If we only have legal characters, we can skip sanitizing the path
-			$legalRegex = '/[^0-9a-zA-Z$\-\_\.\+\!\*\'\(\)\,\~\:\/\[\]\@\;\=\%]/';
+			$legalRegex = '/[^0-9a-zA-Z$\-\_\.\+\!\*\(\)\,\~\:\/\[\]\@\;\=\%]/';
 			if ( preg_match( $legalRegex, $parts['path'] ) ) {
 				// Pluses in the path are legal characters that do not need to be encoded.
 				// Some URLs don't like the plus encoded.
@@ -837,7 +837,7 @@ class CheckIfDead {
 			// There are legal characters that do not need encoding in the query
 			// and some webservers cannot handle these being encoded
 			// If we only have legal characters, we can skip sanitizing the query
-			$legalRegex = '/[^0-9a-zA-Z$\-\_\.\+\!\*\'\(\)\,\~\:\[\]\@\;\&\=\%]/';
+			$legalRegex = '/[^0-9a-zA-Z$\-\_\.\+\!\*\(\)\,\~\:\[\]\@\;\&\=\%]/';
 			if ( preg_match( $legalRegex, $parts['query'] ) ) {
 				// Encoding the + means a literal plus in the query.
 				// A plus means a space otherwise.


### PR DESCRIPTION
Parsing services may use ' as a form of syntax.  URLs with these should be encoded.